### PR TITLE
Expose currentVersion and currentBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ N/A
 
 #### Enhancements
 
-N/A
+- Expose `VersionTracker.currentVersion` and `VersionTracker.currentBuild`. They were previously inaccessible due to
+being internal.
 
 #### Bugfixes
 

--- a/Sources/VersionTracker.swift
+++ b/Sources/VersionTracker.swift
@@ -91,12 +91,12 @@ extension VersionTracker {
 
 extension VersionTracker {
 
-    static var currentVersion: String {
+    public static var currentVersion: String {
         let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         return currentVersion as? String ?? ""
     }
 
-    static var currentBuild: String {
+    public static var currentBuild: String {
         let currentVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String)
         return currentVersion as? String ?? ""
     }


### PR DESCRIPTION
`currentVersion` and `currentBuild` were inaccessible due to being internal.