### PR TITLE
Fix iOS Build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "VersionTracker",
-    platforms: [
-        .iOS(.v8), .macOS(.v10_10), .watchOS(.v2), .tvOS(.v9)
-    ],
     products: [
         .library(name: "VersionTracker", targets: ["VersionTracker"])
     ],


### PR DESCRIPTION
The platform specifications cause a build warning in Xcode 12. They're not necessary since VTS supports all versions supported by Xcode versions that support Swift Package Manager.

Details in nanopb/nanopb#585, firebase/firebase-ios-sdk#6449, https://forums.swift.org/t/minimum-ios-version-xcode-12-and-build-warnings/40224, and https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md